### PR TITLE
LIFF.initの認証処理をアプリ全体に変更

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 
 // router
-import { Routes } from './routes';
+import { Routes } from './routes/routes';
 
 // redux
 import { Provider } from 'react-redux';
@@ -11,7 +10,7 @@ import { store } from './store/index';
 // asset
 import './assets/style/index.scss';
 
-ReactDOM.render(
+render(
   <Provider store={store}>
     <Routes />
   </Provider>,

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,5 +1,4 @@
-/* eslint @typescript-eslint/ban-ts-comment: 0 */
-import React, { FC, useEffect, useCallback } from 'react';
+import React, { FC, useEffect } from 'react';
 
 // router
 import { useHistory } from 'react-router-dom';
@@ -8,10 +7,6 @@ import { useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../store';
 import { updateOpen, updateContent, updateClass } from '../store/dialog';
-import { updateUserid } from '../store/user';
-
-// liff
-import liff from '@line/liff';
 
 // WebVitals
 import reportWebVitals from '../reportWebVitals';
@@ -32,28 +27,6 @@ export const Home: FC = () => {
 
   const { userid } = useSelector((state: RootState) => state.user);
 
-  // LIFFにログインする
-  const actLoginLiff = useCallback(() => {
-    try {
-      liff
-        .init({
-          liffId: process.env.REACT_APP_LIFF_ID as string,
-        })
-        .then(() => {
-          if (!liff.isInClient() && !liff.isLoggedIn()) liff.login({}); // LIFFブラウザで起動していない場合はLINEログインする
-
-          // LINE ユーザIDをstoreへ保存
-          const decordIdToken = liff.getDecodedIDToken();
-          if (decordIdToken?.sub) dispatch(updateUserid(decordIdToken.sub));
-        })
-        .catch(err => {
-          console.log('error', err);
-        });
-    } catch (err) {
-      alert(`LIFF initialize failed ${err}`);
-    }
-  }, [dispatch]);
-
   // ダイアログ
   const openDialog = () => {
     const dialogBody = (
@@ -69,24 +42,12 @@ export const Home: FC = () => {
   // ページタイトル
   useEffect(() => {
     document.title = `HOME`;
-  }, [actLoginLiff, history]);
+  }, []);
 
   // ページを表示したとき
   useEffect(() => {
-    // LIFFブラウザで起動していない場合はこのタイミングでliff.init
-    if (!liff.isInClient()) actLoginLiff();
     reportWebVitals(console.log);
-  }, [actLoginLiff]);
-
-  // ページを表示したとき
-  // LINEアプリ から LIFF を起動したとき対策
-  window.addEventListener(
-    'load',
-    () => {
-      if (!userid) actLoginLiff();
-    },
-    { once: true }
-  );
+  }, []);
 
   return (
     <div className={`l-page ${style.home}`}>

--- a/src/routes/private.tsx
+++ b/src/routes/private.tsx
@@ -4,13 +4,13 @@ import { FC } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 // pages
-import { Home } from './pages/home';
-import { Sub } from './pages/sub';
+import { Home } from '../pages/home';
+import { Sub } from '../pages/sub';
 
 // layout
-import { Dialog } from './layout/dialog';
+import { Dialog } from '../layout/dialog';
 
-export const Routes: FC = () => {
+export const Private: FC = () => {
   return (
     <BrowserRouter>
       <Switch>

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,0 +1,47 @@
+import { FC, useEffect, useCallback } from 'react';
+
+// redux
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../store';
+import { updateUserid } from '../store/user';
+
+// liff
+import liff from '@line/liff';
+
+// component
+import { Private } from './private';
+
+export const Routes: FC = () => {
+  const dispatch = useDispatch();
+  const { userid } = useSelector((state: RootState) => state.user);
+
+  // LIFFにログインする
+  const doLoginLiff = useCallback(() => {
+    try {
+      liff
+        .init({
+          liffId: process.env.REACT_APP_LIFF_ID as string,
+        })
+        .then(() => {
+          if (!liff.isInClient() && !liff.isLoggedIn()) liff.login({}); // LIFFブラウザで起動していない場合はLINEログインする
+
+          // LINE ユーザIDをstoreへ保存
+          const decordIdToken = liff.getDecodedIDToken();
+          if (decordIdToken?.sub) dispatch(updateUserid(decordIdToken.sub));
+        })
+        .catch(err => {
+          console.log('error', err);
+        });
+    } catch (err) {
+      alert(`LIFF initialize failed ${err}`);
+    }
+  }, [dispatch]);
+
+  // ページを表示したとき
+  useEffect(() => {
+    // LIFFブラウザで起動していない場合はこのタイミングでliff.init
+    if (!liff.isInClient()) doLoginLiff();
+  }, [doLoginLiff]);
+
+  return userid ? <Private /> : <></>;
+};


### PR DESCRIPTION
扉ページのhomeへ設定していたLiff.initを、上層のroutesへ移動。認証がアプリ全体に係るよう改修。